### PR TITLE
Fix typo in doc (matrix field)

### DIFF
--- a/docs/_sources/specification/point_cloud.md.txt
+++ b/docs/_sources/specification/point_cloud.md.txt
@@ -232,7 +232,7 @@ With those definitions, any parser supporting the full glTF specification is a v
 | camera | **ignored** ||
 | children | **ignored** ||
 | skin | **ignored** ||
-| matrix | **supported** | Note that glTF follows a y-up convention. Points in a z-up coordinate system could be written without conversion with the following anti-clockwise rotation around the x-axis [[1, 0, 0, 0], [0, 0, -1, 0],[0, 1, 0, 0], [0, 0, 0, 1]] defined here. |
+| matrix | **supported** | Note that glTF follows a y-up convention. Points in a z-up coordinate system could be written without conversion by specifying a z-up to y-up rotation here. When written in the format required for this property (4x4 column-major matrix) that rotation is [1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1]. |
 | rotation | **unsupported** | rotation support is covered by the affine matrix transform|
 | translation | **unsupported** | translation support is covered by the affine matrix transform |
 | weights | **ignored** ||

--- a/docs/_sources/specification/point_cloud.md.txt
+++ b/docs/_sources/specification/point_cloud.md.txt
@@ -232,7 +232,7 @@ With those definitions, any parser supporting the full glTF specification is a v
 | camera | **ignored** ||
 | children | **ignored** ||
 | skin | **ignored** ||
-| matrix | **supported** | Note that glTF follows a y-up convention. Points in a z-up coordinate system could be written without conversion with the following anti-clockwise rotation around the x-axis [[1, 0, 0, 0], [0, 0, -1, 0],[0, 1, 0, 0], [0, 0, 0 0]] defined here. |
+| matrix | **supported** | Note that glTF follows a y-up convention. Points in a z-up coordinate system could be written without conversion with the following anti-clockwise rotation around the x-axis [[1, 0, 0, 0], [0, 0, -1, 0],[0, 1, 0, 0], [0, 0, 0, 1]] defined here. |
 | rotation | **unsupported** | rotation support is covered by the affine matrix transform|
 | translation | **unsupported** | translation support is covered by the affine matrix transform |
 | weights | **ignored** ||


### PR DESCRIPTION
Fix what I think is a typo in the docs. I understand the last entry in the transformation matrix should be one. Either way, I comma is certainly missing.

https://pix4d.github.io/opf-spec/specification/point_cloud.html#node

![image](https://github.com/Pix4D/opf-spec/assets/7440734/1100d3a4-f2bf-4e66-a498-891e27f69e10)
